### PR TITLE
chore: Add Retrofit, OkHttp and Gson Converter dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,15 @@ dependencies {
     //Koin
     implementation(libs.koin.android)
 
+    // Retrofit
+    implementation(libs.retrofit)
+    // OkHttp
+    implementation(platform(libs.okhttp.bom))
+    implementation(libs.okhttp)
+    implementation(libs.logging.interceptor)
+    //Gson
+    implementation(libs.converter.gson)
+
     //Test
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
 composeBom = "2024.04.01"
 lottie-compose= "6.5.0"
+retrofit = "2.11.0"
+okhttpBom= "4.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,9 +29,20 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
-# Lottie
+# Koin
 koin-android = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koinAndroid" }
+
+# Lottie
 lottie-compose = { module = "com.airbnb.android:lottie-compose", version.ref = "lottie-compose" }
+
+# Retrofit
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+#OkHttp
+okhttp = { module = "com.squareup.okhttp3:okhttp" }
+okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttpBom" }
+logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor" }
+#Gson Converter
+converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This Pull Request adds the Retrofit, OkHttp, and Gson Converter dependencies to the project. These libraries are essential for making network requests and processing JSON data in Android applications.

- **Retrofit:** A type-safe HTTP client for Android and Java. It makes it easier to interact with REST APIs by allowing you to define endpoints and data models declaratively.
- **OkHttp:** An efficient and modern HTTP client. It is used by Retrofit to perform the network requests.
- **Gson Converter:** A converter that allows Retrofit to use the Gson library to serialize and deserialize JSON objects. This makes it easier to work with JSON data received and sent by the API.

**Motivation:**

Retrofit, OkHttp, and Gson Converter are widely used in Android applications for network requests and JSON data processing. Adding them to the project enables the application to communicate with REST APIs and process JSON data efficiently.