### PR TITLE
Refactor: Adjust GetRideEstimateUseCase and RideEstimate data structures

### DIFF
--- a/app/src/main/java/com/voyager/data/model/mapper/RideEstimateMapper.kt
+++ b/app/src/main/java/com/voyager/data/model/mapper/RideEstimateMapper.kt
@@ -11,11 +11,11 @@ import com.voyager.domain.model.ride.RideEstimate
 
 fun RideEstimateResponse.toDomain(): RideEstimate {
     return RideEstimate(
-        origin = origin.toDomain(),
-        destination = destination.toDomain(),
+        origin = origin?.toDomain(),
+        destination = destination?.toDomain(),
         distance = distance,
         duration = duration,
-        options = options.map { it.toDomain() },
+        options = options?.map { it.toDomain() },
         routeResponse = routeResponse
     )
 }
@@ -29,12 +29,12 @@ fun AddressResponse.toDomain(): Address {
 
 fun OptionResponse.toDomain(): Option {
     return Option(
-        review= review.toDomain(),
+        review = review?.toDomain(),
         name= name,
         description= description,
-        id= id,
-        value= value,
-        vehicle= vehicle
+        id = id,
+        vehicle= vehicle,
+        value= value
     )
 }
 

--- a/app/src/main/java/com/voyager/data/remote/model/ride_estimate_response/RideEstimateResponse.kt
+++ b/app/src/main/java/com/voyager/data/remote/model/ride_estimate_response/RideEstimateResponse.kt
@@ -3,45 +3,52 @@ package com.voyager.data.remote.model.ride_estimate_response
 import com.google.gson.annotations.SerializedName
 
 data class RideEstimateResponse (
-    @SerializedName("duration")
-    val duration: String,
-    @SerializedName("distance")
-    val distance: String,
     @SerializedName("origin")
-    val origin: AddressResponse,
-    @SerializedName("route_response")
-    val routeResponse: String,
+    val origin: AddressResponse?,
     @SerializedName("destination")
-    val destination: AddressResponse,
+    val destination: AddressResponse?,
+    @SerializedName("distance")
+    val distance: Number?,
+    @SerializedName("duration")
+    val duration: String?,
     @SerializedName("options")
-    val options: List<OptionResponse>
+    val options: List<OptionResponse>?,
+    @SerializedName("route_response")
+    val routeResponse: String?
 )
 
 data class AddressResponse (
     @SerializedName("latitude")
-    val latitude: String,
+    val latitude: Number?,
     @SerializedName("longitude")
-    val longitude: String
+    val longitude: Number?
 )
 
 data class OptionResponse (
-    @SerializedName("review")
-    val review: ReviewResponse,
-    @SerializedName("name")
-    val name: String,
-    @SerializedName("description")
-    val description: String,
     @SerializedName("id")
-    val id: String,
-    @SerializedName("value")
-    val value: String,
+    val id: Number?,
+    @SerializedName("name")
+    val name: String?,
+    @SerializedName("description")
+    val description: String?,
     @SerializedName("vehicle")
-    val vehicle: String
+    val vehicle: String?,
+    @SerializedName("review")
+    val review: ReviewResponse?,
+    @SerializedName("value")
+    val value: Number?,
 )
 
 data class ReviewResponse (
     @SerializedName("rating")
-    val rating: String,
+    val rating: Number?,
     @SerializedName("comment")
-    val comment: String
+    val comment: String?
+)
+
+data class RideEstimateErrorResponse (
+    @SerializedName("error_code")
+    val errorCode: Number?,
+    @SerializedName("error_description")
+    val errorDescription: String?
 )

--- a/app/src/main/java/com/voyager/domain/model/ride/RideEstimate.kt
+++ b/app/src/main/java/com/voyager/domain/model/ride/RideEstimate.kt
@@ -1,29 +1,29 @@
 package com.voyager.domain.model.ride
 
 data class RideEstimate (
-    val duration: String,
-    val distance: String,
-    val origin: Address,
-    val routeResponse: String,
-    val destination: Address,
-    val options: List<Option>
+    val origin: Address?,
+    val destination: Address?,
+    val distance: Number?,
+    val duration: String?,
+    val options: List<Option>?,
+    val routeResponse: String?
 )
 
 data class Address (
-    val latitude: String,
-    val longitude: String
+    val latitude: Number?,
+    val longitude: Number?
 )
 
 data class Option (
-    val review: Review,
-    val name: String,
-    val description: String,
-    val id: String,
-    val value: String,
-    val vehicle: String
+    val id: Number?,
+    val name: String?,
+    val description: String?,
+    val vehicle: String?,
+    val review: Review?,
+    val value: Number?
 )
 
 data class Review (
-    val rating: String,
-    val comment: String
+    val rating: Number?,
+    val comment: String?
 )

--- a/app/src/main/java/com/voyager/domain/usecase/GetRideEstimateUseCase.kt
+++ b/app/src/main/java/com/voyager/domain/usecase/GetRideEstimateUseCase.kt
@@ -1,5 +1,6 @@
 package com.voyager.domain.usecase
 
+import com.voyager.data.model.mapper.toDomain
 import com.voyager.data.remote.model.request_body.RideEstimateRequestBody
 import com.voyager.domain.repository.RideRepository
 
@@ -7,6 +8,6 @@ class GetRideEstimateUseCase(
     private val repository: RideRepository
 ) {
 
-    suspend operator fun invoke(body: RideEstimateRequestBody) = repository.getRideEstimate(body)
+    suspend operator fun invoke(body: RideEstimateRequestBody) = repository.getRideEstimate(body).toDomain()
 
 }


### PR DESCRIPTION
This PR introduces the following refactoring changes:

- Adjusts the `invoke` method of `GetRideEstimateUseCase` to return a domain layer `RideEstimate` object.
- Adjusts the attributes of `RideEstimateResponse` and `RideEstimate` to be nullable.
- Refactors numerical attributes to the `Number` type.

These changes aim to improve the code structure, making it more robust and flexible in handling various API response scenarios.

**Changes:**

- **`GetRideEstimateUseCase`:**
    - The `invoke` method now returns a domain layer `RideEstimate` object instead of a data layer `RideEstimateResponse`.
    - Logic for mapping `RideEstimateResponse` to `RideEstimate` is added within the `invoke` method.
- **`RideEstimateResponse` and `RideEstimate`:**
    - Attributes are modified to be nullable, allowing for cases where the API might not return all values.
    - Numerical attributes are refactored to the `Number` type, providing more generic and flexible handling.

**Benefits:**

- **Improved code structure:** Enhances separation of concerns by using domain objects in the use case layer.
- **Increased robustness:** Handles potential null values in API responses gracefully.
- **Enhanced flexibility:** Allows for different numerical types to be used for attributes.